### PR TITLE
Clarify a confusing custom-build subtlety

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 * www - Folder: holds all files to be served by nginx
 * nginx.conf.erb - Optional File: overrides `conf/nginx.conf.erb`
 * mime.types - Optional File: overrides `conf/mime.types`
-* custom-build - Optional File: executes commands before build is finished
+* custom-build - Optional File: executes commands before build is finished. Note that this script does not run in the application root. To execute commands in the application root you must do `cd "$1"`.
 
 ## Environment Variables
 * root - Optional: overrides root directory


### PR DESCRIPTION
I spent a long time debugging an issue with my script due to the misconception I had about where the script was being run.

My script was supposed to generate the `www` folder, but since it did not generate it in the right directory, the build always failed.

Also perhaps a clearer error message for the cases when `www/` does not exist might be useful.
